### PR TITLE
Use Object.assign over xtend

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var http = require('http')
 var https = require('https')
 var parseUrl = require('url').parse
-var xtend = require('xtend')
 var debug = require('debug')('request-stream')
 
 module.exports = requester('GET')
@@ -34,7 +33,7 @@ function requester (method) {
       maxRedirects: 10
     }
 
-    var reqOpts = xtend(defaults, opts)
+    var reqOpts = Object.assign({}, defaults, opts)
     var req = mod.request(reqOpts)
     debug('request %j', reqOpts)
     req.on('error', done)

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "homepage": "https://github.com/maxogden/request-stream#readme",
   "dependencies": {
-    "debug": "^2.2.0",
-    "xtend": "^4.0.1"
+    "debug": "^2.2.0"
   },
   "devDependencies": {
     "standard": "^5.4.1",


### PR DESCRIPTION
`Object.assign` natively does the same job as `xtend`, so using it means there is no longer a need for an `xtend` dependency!